### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -33,7 +33,7 @@ def text_to_speech(text, voice_name='en-US-JennyNeural'):
 
         # Check result
         if result.reason == speechsdk.ResultReason.SynthesizingAudioCompleted:
-            print("Speech synthesized for text [{}]".format(text))
+            print("Speech synthesized successfully.")
             return result.audio_data  # This is in MP3 format
         elif result.reason == speechsdk.ResultReason.Canceled:
             cancellation_details = result.cancellation_details


### PR DESCRIPTION
Potential fix for [https://github.com/passadis/react-multiagents-speech/security/code-scanning/6](https://github.com/passadis/react-multiagents-speech/security/code-scanning/6)

To address the issue, we need to ensure that sensitive or untrusted data is not logged in clear text. The best way to fix this is to either remove the log statement printing the input text altogether or, if logging is necessary, redact the actual content and log only metadata (such as data size or a hash). Since the log in question is simply for tracing which input text was synthesized, and given the potential for this text to include secrets, we should simply remove or replace the log message with a more generic variant that does not display the full text. Specifically, in `backend/app.py`, line 36 in the `text_to_speech` function, replace:

```python
print("Speech synthesized for text [{}]".format(text))
```

with either a generic log statement:

```python
print("Speech synthesized for provided text input.")
```

or remove the logging line altogether. No extra imports or definitions are required; this change only affects the log output.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
